### PR TITLE
fix: refresh product data after saving

### DIFF
--- a/actions/product-action.ts
+++ b/actions/product-action.ts
@@ -132,8 +132,6 @@ export async function updateProduct(
     };
   }
 
-  revalidatePath('/');
-
   return {
     success: true,
     message: 'Product updated successfully',
@@ -180,8 +178,6 @@ export async function createProduct(
       message: 'Product could not be created',
     };
   }
-
-  revalidatePath('/');
 
   return {
     success: true,

--- a/components/product-modal.tsx
+++ b/components/product-modal.tsx
@@ -2,6 +2,7 @@
 
 import { useActionState, useEffect } from 'react';
 import { useFormStatus } from 'react-dom';
+import { useRouter } from 'next/navigation';
 
 import ProductInfoForm from './forms/product-info-form';
 import { Category, Product } from '@/app/types';
@@ -34,6 +35,7 @@ function SaveProductButton() {
 }
 
 export default function ProductModal({ mode, onClose, categories, product }: ProductModalProps) {
+    const router = useRouter();
     const title = mode === 'add' ? 'Add Product' : 'Edit Product';
 
     // choose the server action based on whether the modal is adding or editing a product
@@ -55,11 +57,13 @@ export default function ProductModal({ mode, onClose, categories, product }: Pro
 
         if (state.success) {
             toast.success(state.message);
+            // Refresh to show the saved product in product list
+            router.refresh();
             onClose();
         } else {
             toast.error(state.message);
         }
-    }, [state, onClose]);
+    }, [state, router, onClose]);
 
     return (
         <div className="fixed inset-0 flex items-center justify-center bg-black/50">


### PR DESCRIPTION
When running `npm run build` + `npm run start` instead of `npm run dev:full`, saving a product in the Add/Edit Product modal got stuck on "Saving...". The product was still saved correctly.

Removed `revalidatePath('/')` and added `router.refresh()` after saving so the product list updates without having to refresh page manually